### PR TITLE
DEVOPS-374: Adds IAM role for GitHub Actions OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,5 @@ on:
 jobs:
   lint:
     name: "Lint"
-    uses: opstimus/github-actions-terraform-lint/.github/workflows/lint.yml@v1
+    uses: opstimus/github-actions-terraform/.github/workflows/lint.yml@v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This Terraform module creates an Amazon ECR (Elastic Container Registry) repository and configures its policies. It supports setting image tag mutability, image scanning on push, and granting access to specified AWS accounts.
+This Terraform module creates an Amazon ECR (Elastic Container Registry) repository and configures its policies. It supports setting image tag mutability, image scanning on push, and granting access to specified AWS accounts. Optionally creates an IAM managed policy that can be attached to an IAM user or IAM role for GitHub Actions OIDC authentication.
 
 ## Requirements
 
@@ -26,7 +26,9 @@ This Terraform module creates an Amazon ECR (Elastic Container Registry) reposit
 | image_tag_mutability | Tag mutability for images (`true` for IMMUTABLE)    | bool   | true    |    no    |
 | scan_on_push        | Enable image scanning on push                        | bool   | false   |    no    |
 | account_ids         | List of AWS account IDs that can access the repository | list   | -       |   yes    |
-| create_iam_user     | Enable to create IAM user for ECR tasks              | bool   | false   | no       |
+| create_iam_user     | Enable to create IAM user for ECR tasks              | bool   | false   |    no    |
+| create_iam_role     | Enable to create IAM role for GitHub Actions OIDC    | bool   | false   |    no    |
+| github_oidc_subjects | List of GitHub OIDC subjects (e.g., `repo:owner/repo:ref:refs/heads/main`) | list(string) | [] |    no    |
 
 ## Outputs
 
@@ -38,8 +40,6 @@ This Terraform module creates an Amazon ECR (Elastic Container Registry) reposit
 
 ### Basic ECR Repository Creation
 
-This example demonstrates how to use the module to create an ECR repository with specific configurations.
-
 ```hcl
 module "ecr_repository" {
   source                = "github.com/opstimus/terraform-aws-ecr?ref=v<RELEASE>"
@@ -50,6 +50,24 @@ module "ecr_repository" {
   scan_on_push          = true
   account_ids           = ["123456789012", "210987654321"]
   create_iam_user       = false
+  create_iam_role       = false
+}
+```
+
+### With GitHub Actions IAM Role
+
+```hcl
+module "ecr_repository" {
+  source                = "github.com/opstimus/terraform-aws-ecr?ref=v<RELEASE>"
+
+  project               = "my-project"
+  service               = "backend"
+  account_ids           = ["123456789012"]
+  create_iam_role       = true
+  github_oidc_subjects  = [
+    "repo:owner/repo:ref:refs/heads/main",
+    "repo:owner/repo:pull_request"
+  ]
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ data "aws_iam_policy_document" "role_trust" {
 
 resource "aws_iam_role" "main" {
   count              = var.create_iam_role ? 1 : 0
-  name               = "${var.project}-${var.service}-ecr-role"
+  name               = "${var.project}-${var.service}-ecr"
   assume_role_policy = data.aws_iam_policy_document.role_trust[0].json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,15 @@ variable "create_iam_user" {
   type    = bool
   default = false
 }
+
+variable "create_iam_role" {
+  type        = bool
+  default     = false
+  description = "Whether to create an IAM role for GitHub Actions OIDC"
+}
+
+variable "github_oidc_subjects" {
+  type        = list(string)
+  default     = []
+  description = "List of GitHub OIDC subjects (e.g., 'repo:owner/repo:ref:refs/heads/main')"
+}


### PR DESCRIPTION
This change introduces the ability to create an IAM role that can be assumed by GitHub Actions workflows using OpenID Connect (OIDC).

It also replaces the aws_iam_user_policy resource with an aws_iam_policy resource and creates an aws_iam_user_policy_attachment to attach the policy to the IAM user. This simplifies policy management.

Two new variables are introduced: `create_iam_role` to control the creation of the IAM role and `github_oidc_subjects` to specify the allowed GitHub OIDC subjects.